### PR TITLE
Feature/vscode link

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -41,6 +41,31 @@ path: /hello.js
 
 </details>
 
+### 静态路径
+<details open>
+<summary> 静态路径 </summary>
+对于 Vault 文件夹外的路径
+<pre><code>```preview
+path: C:\source\obsidian-code-preview\src\main.ts
+pathResolve: true
+```</code></pre>
+</details>
+
+### VSCode 集成
+<details open>
+<summary> VSCode 链接 </summary>
+在代码块顶部包含一个链接，用于在 VSCode 中打开文件
+<pre><code>```preview
+path: /hello.js
+includeVSCodeLink: true
+```</code></pre>
+<pre><code>```preview
+path: C:\source\obsidian-code-preview\src\main.ts
+pathResolve: true
+includeVSCodeLink: true
+```</code></pre>
+</details>
+
 ### 代码块语言
 
 代码块的语言默认使用文件的扩展名。
@@ -218,6 +243,8 @@ highlight:
 | end | 预览结束行数 | number or string or RegExp |  - |
 | highlight | 高亮的行 | number or string or RegExp | - |
 | linenumber | 是否显示行号, 优先级大于插件配置 | true or false | 插件配置 |
+| includeVSCodeLink | 显示一个链接以在 VSCode 中打开文件 | true 或 false | false |
+| pathResolve | 启用解析 Vault 外部的静态路径 | true 或 false | false |
 
 ## 插件配置
 
@@ -235,4 +262,5 @@ highlight:
 
 ## Thank
 
+[CloudyOne](https://github.com/cloudyone)，感谢其添加了 VSCodeLink 支持 🙌 
 linenumber, highlight 基于[obsidian-better-codeblock](https://github.com/stargrey/obsidian-better-codeblock)基础实现

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Obsidian Code Previews Plugin
 
-Original Repo: https://github.com/stargrey/obsidian-better-codeblock
-
-I noticed that despite issues being submitted to the old repo, there's been no update. Any non-relative pathing wasn't working, so I wanted to fix that, and then add a few features.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Obsidian Code Previews Plugin
 
+[中文](./README.CN.md)
 
 ## Example
 
@@ -40,6 +41,34 @@ path: /sub/color.css
 path: /hello.js
 ```</code></pre>
 
+</details>
+
+<details open>
+<summary> Static Path </summary>
+For paths outside of the Vault folder
+
+<pre><code>```preview
+path: C:\source\obsidian-code-preview\src\main.ts
+pathResolve: true
+```</code></pre>
+</details>
+
+### VSCode Integration
+
+<details open>
+<summary> VSCode Link </summary>
+Includes a link at the top of the code block to open the file in VSCode
+
+<pre><code>```preview
+path: /hello.js
+includeVSCodeLink: true
+```</code></pre>
+
+<pre><code>```preview
+path: C:\source\obsidian-code-preview\src\main.ts
+pathResolve: true
+includeVSCodeLink: true
+```</code></pre>
 </details>
 
 ### CodeBlock language
@@ -219,6 +248,8 @@ highlight:
 | end | preview end line. | number or string or RegExp |  - |
 | highlight | highlight lines | number or string or RegExp | - |
 | linenumber | display line Numbers, priority is greater than the plugin configuration | true or false | plugin config |
+| includeVSCodeLink | displays a link to open the file in VSCode | true or false | false |
+| pathResolve | enables resolving of static paths outside of the vault | true or false | false |
 
 ## Plugin configuration
 
@@ -236,4 +267,5 @@ highlight:
 
 ## Thank
 
-linenumber, highlight Based on [obsidian-better-codeblock](https://github.com/stargrey/obsidian-better-codeblock) his implementation
+[CloudyOne](https://github.com/cloudyone), for adding VSCodeLink support 🙌 
+* linenumber, highlight Based on [obsidian-better-codeblock](https://github.com/stargrey/obsidian-better-codeblock) his implementation


### PR DESCRIPTION
* Added VS Code link support with includeVSCodeLink setting.
* Added static path support with pathResolve setting
* Added documentation to the README file on how to use these two new parameters.

* 通过 `includeVSCodeLink` 设置添加了 VS Code 链接支持。
* 通过 `pathResolve` 设置添加了静态路径支持。
* 在 README 文件中添加了关于如何使用这两个新参数的文档。